### PR TITLE
Fixing domain bug

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site
 title: DSA {Chapter Name}
 description: The Democratic Socialists of America in {Location}
-url: https://dsausa.org
+url: http://localhost:4000 # replace with your own domain name
 logo: dsa_logo.png                                       # Site logo
 locale: en_US
 


### PR DESCRIPTION
Annoyingly, if you set `url` in `_config.yml` to something other than your own actual domain (or another domain where static assets can be found at the right paths), everything bombs.

This changes the `url` to `http://localhost:4000`, which makes things OK.

To me, this suggests that the URLs on the pages are set up in a way that's not very good. It should not be necessary to refer to the domain like this, and that makes it hard to develop locally.

TODO: root out this issue by changing the URL structures.
